### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled format string

### DIFF
--- a/src/frontend/compiler.c
+++ b/src/frontend/compiler.c
@@ -356,7 +356,7 @@ static void compiler_advance(void) {
             break;
         }
 
-        compiler_error_at_current(parser.current.start);
+        compiler_error_at_current("%s", parser.current.start);
     }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/FrederikTobner/Cellox/security/code-scanning/2](https://github.com/FrederikTobner/Cellox/security/code-scanning/2)

Use a constant format string when reporting lexer/parser error text.  
Specifically in `src/frontend/compiler.c`, change the call in `compiler_advance()` from:

- `compiler_error_at_current(parser.current.start);`

to:

- `compiler_error_at_current("%s", parser.current.start);`

This preserves behavior (printing the same message text) while preventing user input from being interpreted as a format string by downstream `vfprintf`. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
